### PR TITLE
Added server check for entire path existence

### DIFF
--- a/NtlLib/Server/NtlSystem/NtlFile.cpp
+++ b/NtlLib/Server/NtlSystem/NtlFile.cpp
@@ -20,7 +20,7 @@
 
 #include <io.h>
 #include <tchar.h>
-
+#include <filesystem>
 
 
 //-----------------------------------------------------------------------------------
@@ -71,6 +71,14 @@ void CNtlFile::Destroy()
 //-----------------------------------------------------------------------------------
 int CNtlFile::Create(LPCTSTR lpszFileName, int nOperationFlag /* = _O_CREAT | _O_APPEND | _O_RDWR */, int nSharingFlag /* = _SH_DENYNO */, int nPermissionMode /* = _S_IREAD | _S_IWRITE */, bool bAutoClose /* = false */)
 {
+	if ((nOperationFlag & _O_CREAT) == _O_CREAT)		//if the file should be created
+	{
+		auto path = std::filesystem::path(lpszFileName).remove_filename();
+
+		if (!std::filesystem::exists(path))				//check if the path exists
+			std::filesystem::create_directories(path);  //and create directories
+	}
+
 	int rc = _tsopen_s( &m_hFile, lpszFileName, nOperationFlag, nSharingFlag, nPermissionMode );
 	if( NTL_SUCCESS != rc )
 	{

--- a/NtlLib/Server/NtlSystem/NtlSystem.vcxproj
+++ b/NtlLib/Server/NtlSystem/NtlSystem.vcxproj
@@ -50,6 +50,7 @@
       <StringPooling>false</StringPooling>
       <FunctionLevelLinking>false</FunctionLevelLinking>
       <FloatingPointModel>Fast</FloatingPointModel>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemGroup>


### PR DESCRIPTION
NtlSystem: When a file is going to be created, if the path doesn't exists then will be created.

This requires C++17 for NtlSystem.